### PR TITLE
Changed link pointing to Dive Into HTML5

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       all versions of HTML and allows you to mark up basic concepts like
       people, places, events, recipes, and audio.
       </dd>
-      <dt><a href="http://diveintohtml5.org/extensibility.html">Microdata</a></dt>
+      <dt><a href="http://diveintohtml5.ep.io/extensibility.html">Microdata</a></dt>
       <dd>The chapter on Microdata in the Dive into HTML5 book is a good
       introduction to the next generation of Microformats. Microdata is the
       newest addition to the structured data markup technologies, created in


### PR DESCRIPTION
As of 5 Oct. 2011 http://diveintohtml5.org/ was returning a 410.  I have modified the "Microdata" link referencing Dive Into HTML5 to point to the mirror domain http://diveintohtml5.ep.io/.  As this work was "licensed under the CC-BY-3.0 license" this should not present a licensing problem.
